### PR TITLE
Set $OBJCXX in Guides/Setup/Linux/building-linux.md

### DIFF
--- a/source/Guides/Setup/Linux/building-linux.md
+++ b/source/Guides/Setup/Linux/building-linux.md
@@ -13,6 +13,7 @@ Environment:
 ```sh
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++
+export OBJCXX=$CXX
 export PATH=/usr/local/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 export LD=/usr/bin/ld.lld


### PR DESCRIPTION
GNUStep make doesn't seem to fall back to `$CXX` for the Objective-C++ compiler. If `$OBJCXX` is not set on a system that has g++, it will autodetect that as the Objective-C++ compiler to use instead of clang++.