### PR TITLE
fix link in Contributing/index.md

### DIFF
--- a/source/About/Contributing/index.md
+++ b/source/About/Contributing/index.md
@@ -12,6 +12,6 @@ CodeStyle
 
 ## Contact us
 
-You can send emails to the mailing list [`<discuss-gnustep@gnu.org>`](https://mail.gnu.org/mailman/listinfo/discuss-gnustep), and you can subscribe to that mailing list at the link above.
+You can send emails to the mailing list [`<discuss-gnustep@gnu.org>`](https://lists.gnu.org/mailman/listinfo/discuss-gnustep), and you can subscribe to that mailing list at the link above.
 
 Some of our developers are also using [a Zulip instance](https://gnustep.zulipchat.com/join/sdwgq3wsotq6hnosat2zynn4/).


### PR DESCRIPTION
This PR fixes a link in About/Contributing/index.html There are more dead links in Guides/App/1_Intro/index.html, but I'll open an issue for it.